### PR TITLE
Cleanup; Add `main`. Change CLI parser to use Python stdlib's `argparse`. Configuration file.

### DIFF
--- a/dreamify.cfg
+++ b/dreamify.cfg
@@ -1,12 +1,24 @@
 # Specify the model to use.
 [model]
-model_path = /home/vagrant/caffe/models/bvlc_googlenet
+# Default model (BVLC GoogLeNet)
+#model_path = /home/vagrant/caffe/models/bvlc_googlenet
+#net_fn = %(model_path)s/deploy.prototxt
+#param_fn = %(model_path)s/bvlc_googlenet.caffemodel
+
+# Oxford 102 category flower model
+model_path = /home/vagrant/caffe/models/oxford102
 net_fn = %(model_path)s/deploy.prototxt
-param_fn = %(model_path)s/bvlc_googlenet.caffemodel
-# To use googlenet_places205 dataset:
+param_fn = %(model_path)s/oxford102.caffemodel
+
+# MIT Hybrid-CNN model
+#model_path = /home/vagrant/caffe/models/Places_hybridCNN
+#net_fn = %(model_path)s/hybridCNN_deploy_upgraded.prototxt
+#param_fn = %(model_path)s/hybridCNN_iter_700000_upgraded.caffemodel
+
+# MIT Places-CNN Places205-GoogLeNet model
 #model_path = /home/vagrant/caffe/models/googlenet_places205
 #net_fn = deploy_places205.protxt
-#param_fn = googlelet_places205_train_iter_2400000.caffemodel
+#param_fn = googlenet_places205_train_iter_2400000.caffemodel
 
 # Parms for the caffe Classifier.
 [net]

--- a/dreamify.cfg
+++ b/dreamify.cfg
@@ -1,0 +1,18 @@
+# Specify the model to use.
+[model]
+model_path = /home/vagrant/caffe/models/bvlc_googlenet
+net_fn = %(model_path)s/deploy.prototxt
+param_fn = %(model_path)s/bvlc_googlenet.caffemodel
+
+# Parms for the caffe Classifier.
+[net]
+# ImageNet mean, training set dependent.
+mean = 104.0, 116.0, 122.0
+# The reference model has channels in BGR order instead of RGB.
+channel_swap = 2, 1, 0
+
+# Controls for gradient ascent steps (found in `make_step`).
+[step]
+clip = True
+step_size = 1.5
+jitter = 32

--- a/dreamify.cfg
+++ b/dreamify.cfg
@@ -3,6 +3,10 @@
 model_path = /home/vagrant/caffe/models/bvlc_googlenet
 net_fn = %(model_path)s/deploy.prototxt
 param_fn = %(model_path)s/bvlc_googlenet.caffemodel
+# To use googlenet_places205 dataset:
+#model_path = /home/vagrant/caffe/models/googlenet_places205
+#net_fn = deploy_places205.protxt
+#param_fn = googlelet_places205_train_iter_2400000.caffemodel
 
 # Parms for the caffe Classifier.
 [net]
@@ -16,3 +20,6 @@ channel_swap = 2, 1, 0
 clip = True
 step_size = 1.5
 jitter = 32
+
+[misc]
+tempfile = tmp.prototxt

--- a/dreamify.py
+++ b/dreamify.py
@@ -1,105 +1,156 @@
-# imports and basic notebook setup
 from cStringIO import StringIO
-import numpy as np
-import scipy.ndimage as nd
-import PIL.Image
 from IPython.display import clear_output, Image, display
 from google.protobuf import text_format
 
-import caffe
+import numpy as np
+import scipy.ndimage as nd
+import PIL.Image
+
+import argparse
 
 import sys
+
+import caffe
+
+
+def parseargs():
+    # Kindly provided by Bystroushaak's `argparse builder`
+    # http://kitakitsune.org/argparse_builder/argparse_builder.html
+    parser = argparse.ArgumentParser(
+        'Generate a "deepdream" image from a JPEG input.')
+    parser.add_argument('--infile', '-i', required=True,
+                        help='''The input image filename. Required. Passing in ''' +
+                        '''the "hidden" parameter 'keys' instead of a filename ''' +
+                        '''will dump the model's layer names to stdout.''')
+    parser.add_argument('--outfile', '-o', default='out',
+                        help='The output image filename. Defaults to <INFILE.png>.')
+    parser.add_argument('--end-name', '-e', default='inception_4c/output',
+                        help='The name of the layer to capture output from. For the ' +
+                        'Google dataset, defaults to "inception_4c/output".')
+    parser.add_argument('--iter-n', '-n', default=10, type=int,
+                        help='Number of iterations per octave. Default 10.')
+    parser.add_argument('--octaves', '-8', default=4, type=int,
+                        help='Number of octaves. Default 4.')
+    parser.add_argument('--oct-scale', '-s', default=1.4, type=float,
+                        help='Octave scale. Default 1.4.')
+    return parser.parse_args()
+
 
 def savearray(a, filename, fmt='png'):
     a = np.uint8(np.clip(a, 0, 255))
     with open(filename, 'wb') as f:
         PIL.Image.fromarray(a).save(f, fmt)
-        #display(Image(data=f.getvalue()))
+        # display(Image(data=f.getvalue()))
 
-model_path = '/home/vagrant/caffe/models/bvlc_googlenet/' # substitute your path here
-net_fn   = model_path + 'deploy.prototxt'
-param_fn = model_path + 'bvlc_googlenet.caffemodel'
 
-# Patching model to be able to compute gradients.
-# Note that you can also manually add "force_backward: true" line to "deploy.prototxt".
-model = caffe.io.caffe_pb2.NetParameter()
-text_format.Merge(open(net_fn).read(), model)
-model.force_backward = True
-open('tmp.prototxt', 'w').write(str(model))
-
-net = caffe.Classifier('tmp.prototxt', param_fn,
-                       mean = np.float32([104.0, 116.0, 122.0]), # ImageNet mean, training set dependent
-                       channel_swap = (2,1,0)) # the reference model has channels in BGR order instead of RGB
-
-# a couple of utility functions for converting to and from Caffe's input image layout
+# A couple of utility functions for converting to and from Caffe's input
+# image layout.
 def preprocess(net, img):
     return np.float32(np.rollaxis(img, 2)[::-1]) - net.transformer.mean['data']
+
+
 def deprocess(net, img):
     return np.dstack((img + net.transformer.mean['data'])[::-1])
 
+
 def make_step(net, step_size=1.5, end='inception_4c/output', jitter=32, clip=True):
     '''Basic gradient ascent step.'''
-
-    src = net.blobs['data'] # input image is stored in Net's 'data' blob
+    # Input image is stored in Net's 'data' blob.
+    src = net.blobs['data']
     dst = net.blobs[end]
+    ox, oy = np.random.randint(-jitter, jitter + 1, 2)
 
-    ox, oy = np.random.randint(-jitter, jitter+1, 2)
-    src.data[0] = np.roll(np.roll(src.data[0], ox, -1), oy, -2) # apply jitter shift
-
+    # Apply jitter shift.
+    src.data[0] = np.roll(np.roll(src.data[0], ox, -1), oy, -2)
     net.forward(end=end)
-    dst.diff[:] = dst.data  # specify the optimization objective
+
+    # Specify the optimization objective.
+    dst.diff[:] = dst.data
     net.backward(start=end)
     g = src.diff[0]
-    # apply normalized ascent step to the input image
-    src.data[:] += step_size/np.abs(g).mean() * g
 
-    src.data[0] = np.roll(np.roll(src.data[0], -ox, -1), -oy, -2) # unshift image
-
+    # Apply normalized ascent step to the input image.
+    src.data[:] += step_size / np.abs(g).mean() * g
+    src.data[0] = np.roll(
+        np.roll(src.data[0], -ox, -1), -oy, -2)  # Unshift image.
     if clip:
         bias = net.transformer.mean['data']
-        src.data[:] = np.clip(src.data, -bias, 255-bias)
+        src.data[:] = np.clip(src.data, -bias, 255 - bias)
+
 
 def deepdream(net, base_img, iter_n=10, octave_n=4, octave_scale=1.4, end='inception_4c/output', clip=True, **step_params):
-    # prepare base images for all octaves
+    # Prepare base images for all octaves.
     octaves = [preprocess(net, base_img)]
-    for i in xrange(octave_n-1):
-        octaves.append(nd.zoom(octaves[-1], (1, 1.0/octave_scale,1.0/octave_scale), order=1))
-
+    for i in xrange(octave_n - 1):
+        octaves.append(
+            nd.zoom(octaves[-1], (1, 1.0 / octave_scale, 1.0 / octave_scale), order=1))
     src = net.blobs['data']
-    detail = np.zeros_like(octaves[-1]) # allocate image for network-produced details
+
+    # Allocate image for network-produced details.
+    detail = np.zeros_like(octaves[-1])
     for octave, octave_base in enumerate(octaves[::-1]):
         h, w = octave_base.shape[-2:]
         if octave > 0:
-            # upscale details from the previous octave
+            # Upscale details from the previous octave.
             h1, w1 = detail.shape[-2:]
-            detail = nd.zoom(detail, (1, 1.0*h/h1,1.0*w/w1), order=1)
-
-        src.reshape(1,3,h,w) # resize the network's input image size
-        src.data[0] = octave_base+detail
+            detail = nd.zoom(detail, (1, 1.0 * h / h1, 1.0 * w / w1), order=1)
+        src.reshape(1, 3, h, w)  # Resize the network's input image size.
+        src.data[0] = octave_base + detail
         for i in xrange(iter_n):
             make_step(net, end=end, clip=clip, **step_params)
-
-            # visualization
+            # Visualization.
             vis = deprocess(net, src.data[0])
-            if not clip: # adjust image contrast if clipping is disabled
-                vis = vis*(255.0/np.percentile(vis, 99.98))
-            #showarray(vis)
+            # Adjust image contrast if clipping is disabled.
+            if not clip:
+                vis = vis * (255.0 / np.percentile(vis, 99.98))
+            # showarray(vis)
             print octave, i, end, vis.shape
             clear_output(wait=True)
 
-        # extract details produced on the current octave
-        detail = src.data[0]-octave_base
-    # returning the resulting image
+        # Extract details produced on the current octave.
+        detail = src.data[0] - octave_base
+    # Return the resulting image.
     return deprocess(net, src.data[0])
 
-if 'keys'==sys.argv[1]:
-    print "\n".join( net.blobs.keys())
-    sys.exit(0)
 
-img = np.float32(PIL.Image.open(sys.argv[1]))
-end_name = sys.argv[3] if len(sys.argv)>3 else 'inception_4c/output'
-iter_n = int(sys.argv[4]) if len(sys.argv)>4 else 10
-octaves = int(sys.argv[5]) if len(sys.argv)>5 else 4
-oct_scale = float(sys.argv[6]) if len(sys.argv)>6 else 1.4
-_=deepdream(net, img, end=end_name, iter_n=iter_n, octave_n=octaves, octave_scale=oct_scale)
-savearray(_, sys.argv[2])
+def main(args):
+    try:
+        # Substitute site-specific info here.
+        model_path = '/home/vagrant/caffe/models/bvlc_googlenet/'
+        net_fn = model_path + 'deploy.prototxt'
+        param_fn = model_path + 'bvlc_googlenet.caffemodel'
+
+        # Patching model to be able to compute gradients.
+        # Note that you can also manually add "force_backward: true" line to
+        # "deploy.prototxt".
+        model = caffe.io.caffe_pb2.NetParameter()
+        text_format.Merge(open(net_fn).read(), model)
+        model.force_backward = True
+        open('tmp.prototxt', 'w').write(str(model))
+        net = caffe.Classifier('tmp.prototxt', param_fn,
+                               # ImageNet mean, training set dependent.
+                               mean=np.float32([104.0, 116.0, 122.0]),
+                               # The reference model has channels in BGR order instead
+                               # of RGB.
+                               channel_swap=(2, 1, 0))
+        if 'keys' == args.infile:
+            print('\n'.join(net.blobs.keys()))
+            return 0
+
+        img = np.float32(PIL.Image.open(args.infile))
+        output = deepdream(net, img, end=args.end_name, iter_n=args.iter_n,
+                           octave_n=args.octaves, octave_scale=args.oct_scale)
+        savearray(output, args.outfile)
+        return 0
+
+    except Exception as e:
+        print(str(e))
+        return 2
+
+
+if __name__ == '__main__':
+    args = parseargs()
+    if args.outfile == 'out':
+        # Split the filename from the extension and replace with 'png'.
+        args.outfile = args.infile.split('.')[0] + '.png'
+    sys.exit(main(args))

--- a/dreamify.py
+++ b/dreamify.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from cStringIO import StringIO
 from IPython.display import clear_output, Image, display
 from google.protobuf import text_format
@@ -12,12 +14,14 @@ import sys
 
 import caffe
 
+# For printing some kind of version identifier from the command line
+# VERSION = '0.2'
 
 def parseargs():
     # Kindly provided by Bystroushaak's `argparse builder`
     # http://kitakitsune.org/argparse_builder/argparse_builder.html
-    parser = argparse.ArgumentParser(
-        'Generate a "deepdream" image from a JPEG input.')
+    parser = argparse.ArgumentParser(description = 'Generate a "deepdream" ' +
+                                     'image from a JPEG input.')
     parser.add_argument('--infile', '-i', required=True,
                         help='''The input image filename. Required. Passing in ''' +
                         '''the "hidden" parameter 'keys' instead of a filename ''' +
@@ -33,6 +37,8 @@ def parseargs():
                         help='Number of octaves. Default 4.')
     parser.add_argument('--oct-scale', '-s', default=1.4, type=float,
                         help='Octave scale. Default 1.4.')
+    # parser.add_argument('--version', '-v', action='version',
+    #                     version='%(prog)s, version {0}'.format(VERSION))
     return parser.parse_args()
 
 

--- a/dreamify.py
+++ b/dreamify.py
@@ -47,7 +47,8 @@ def configure():
     mean_list = [float(_) for _ in cfg.get('net', 'mean').split(',')]
     channel_tuple = tuple(int(_)
                           for _ in cfg.get('net', 'channel_swap').split(','))
-    config = dict(param_fn=cfg.get('model', 'param_fn'),
+    config = dict(model_path=cfg.get('model', 'model_path'),
+                  param_fn=cfg.get('model', 'param_fn'),
                   net_fn=cfg.get('model', 'net_fn'),
                   mean=np.float32(mean_list),
                   channel_swap=channel_tuple,
@@ -74,7 +75,7 @@ def make_net(tempfile, param_fn, mean, channel_swap, ):
     # Following is from https://github.com/Dhar/image-dreamer/issues/7
     # net = caffe.Classifier(MODEL_FILE, PRETRAINED)
     # net.set_raw_scale('data', 255)
-    # net.set_mean('data', np.load(caffe_root +
+    # net.set_mean('data', np.load(config[model_path] +
     #                              'python/caffe/imagenet/ilsvrc_2012_mean.npy'))
     # net.set_channel_swap('data', channel_swap)
     return net


### PR DESCRIPTION
- PEP8!
- Move most end-of-line comments above their related code.
- Copyedit most comments.
- Add `if __name__ = __main__:` so that we're a proper command line program with a single point of entry and (mostly) single point of exit.
- Add nice command line argument parsing/args help using Python stdlib's `argparse` module

I came up with this patch independently of @Tursaanpoika's nice work in #8. I think a proper `main` is always appropriate for a stand-alone command line script.
@donaldm changes in #7 amount to a fork, IMHO. Also, I'm not sure why it's a good idea to use JSON (complex) over Python stdlib's `ConfigParser` (simple), or use the (almost) deprecated and more complicated `optparse` over `argparse`.

I'm looking next at pulling out the model vars (`model_path`, `net_fn`, `param_fn`) into a ConfigParser file, as I agree with @donaldm that it'd be nice for them to be easily configurable, and that it's a bit too involved for the command line. Also, it might be nice to option-ize the output image format and mention in the `--input` help some of the other formats which PIL can handle.
